### PR TITLE
docs: fix a few simple typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ request to the templates repository.
 Documentation for users of the application is provided on the project's
 [wiki page](https://github.com/securestate/king-phisher/wiki). This includes
 steps to help new users get started with their first campaigns. Additional
-technical documentation intended for developers is kept seperate as outlined
+technical documentation intended for developers is kept separate as outlined
 in section below.
 
 ### Code Documentation

--- a/docs/source/development/windows_build.rst
+++ b/docs/source/development/windows_build.rst
@@ -83,7 +83,7 @@ automatically, the last line of
 "[python34]\Lib\site-packages\cx_Freeze\windist.py" needs to be updated from
 ``None`` to ``"TARGETDIR"``.
 
-The ouput example of lines 52-62 of cx_freeze's "windist.py" file, with change
+The output example of lines 52-62 of cx_freeze's "windist.py" file, with change
 applied.
 
 .. code-block:: python

--- a/docs/source/king_phisher/server/graphql/middleware.rst
+++ b/docs/source/king_phisher/server/graphql/middleware.rst
@@ -1,4 +1,4 @@
-:mod:`middlware`
+:mod:`middleware`
 ================
 
 .. module:: king_phisher.server.graphql.middleware

--- a/king_phisher/client/export.py
+++ b/king_phisher/client/export.py
@@ -464,7 +464,7 @@ def _xlsx_write(row, columns, worksheet, row_format=None):
 
 def liststore_to_xlsx_worksheet(store, worksheet, columns, title_format, xlsx_options=None):
 	"""
-	Write the contents of a :py:class:`Gtk.ListStore` to an XLSX workseet.
+	Write the contents of a :py:class:`Gtk.ListStore` to an XLSX worksheet.
 
 	:param store: The store to export the information from.
 	:type store: :py:class:`Gtk.ListStore`

--- a/king_phisher/client/gui_utilities.py
+++ b/king_phisher/client/gui_utilities.py
@@ -428,8 +428,8 @@ def gtk_listbox_populate_labels(listbox, label_strings):
 
 def gtk_listbox_populate_urls(listbox, url_strings, signals=None):
 	"""
-	Format and adds URLs to a list box. Each URL is styeled and added as a
-	seperate entry.
+	Format and adds URLs to a list box. Each URL is styled and added as a
+	separate entry.
 
 	.. versionadded:: 1.14.0
 

--- a/king_phisher/client/mailer.py
+++ b/king_phisher/client/mailer.py
@@ -82,7 +82,7 @@ A named tuple for holding both image and file attachments for a message.
 
 .. py:attribute:: files
 
-	A tuple of :py:class:`~.mime.MIMEBase` instances representing the messsages
+	A tuple of :py:class:`~.mime.MIMEBase` instances representing the messages
 	attachments.
 
 .. py:attribute:: images

--- a/king_phisher/client/widget/extras.py
+++ b/king_phisher/client/widget/extras.py
@@ -139,7 +139,7 @@ class ColumnDefinitionBase(object):
 	"""
 	__slots__ = ('title', 'width')
 	cell_renderer = None
-	"""The :py:class:`~Gtk.CellRenderer` to use for renderering the content."""
+	"""The :py:class:`~Gtk.CellRenderer` to use for rendering the content."""
 	g_type = None
 	"""The type to specify in the context of GObjects."""
 	python_type = None
@@ -254,7 +254,7 @@ class FileChooserDialog(_Gtk_FileChooserDialog):
 		value of target_path in the returned dictionary is an absolute path.
 
 		:param set current_name: The name of the file to save.
-		:return: A dictionary with target_uri and target_path keys representing the path choosen.
+		:return: A dictionary with target_uri and target_path keys representing the path chosen.
 		:rtype: dict
 		"""
 		self.set_action(Gtk.FileChooserAction.SAVE)

--- a/king_phisher/server/pylibc.py
+++ b/king_phisher/server/pylibc.py
@@ -171,7 +171,7 @@ def getgrouplist(user, group=constants.AUTOMATIC, encoding='utf-8'):
 def getpwnam(name, encoding='utf-8'):
 	"""
 	Get the structure containing the fields from the specified entry in the
-	passwrd database. See
+	password database. See
 	`getpwnam(3) <http://man7.org/linux/man-pages/man3/getpwnam.3.html>`_ for
 	more information.
 
@@ -189,7 +189,7 @@ def getpwnam(name, encoding='utf-8'):
 def getpwuid(uid):
 	"""
 	Get the structure containing the fields from the specified entry in the
-	passwrd database. See
+	password database. See
 	`getpwuid(3) <http://man7.org/linux/man-pages/man3/getpwuid.3.html>`_ for
 	more information.
 

--- a/king_phisher/sms.py
+++ b/king_phisher/sms.py
@@ -101,7 +101,7 @@ def send_sms(message_text, phone_number, carrier, from_address=None):
 	:param str phone_number: The phone number to send the SMS to.
 	:param str carrier: The cellular carrier that the phone number belongs to.
 	:param str from_address: The optional address to display in the 'from' field of the SMS.
-	:return: This returns the status of the sent messsage.
+	:return: This returns the status of the sent message.
 	:rtype: bool
 	"""
 	from_address = (from_address or DEFAULT_FROM_ADDRESS)

--- a/king_phisher/utilities.py
+++ b/king_phisher/utilities.py
@@ -350,7 +350,7 @@ def password_is_complex(password, min_len=12):
 	Check that the specified string meets standard password complexity
 	requirements.
 	:param str password: The password to validate.
-	:param int min_len: The mininum length the password should be.
+	:param int min_len: The minimum length the password should be.
 	:return: Whether the strings appears to be complex or not.
 	:rtype: bool
 	"""

--- a/tools/development/cx_freeze.py
+++ b/tools/development/cx_freeze.py
@@ -136,7 +136,7 @@ include_files.append((pytz.__path__[0], 'pytz'))
 include_files.append((requests.__path__[0], 'requests'))
 include_files.append((collections.__path__[0], 'collections'))
 
-# include pip executible
+# include pip executable
 executable_path = os.path.dirname(sys.executable)
 include_files.append((os.path.join(executable_path, 'Scripts'), 'Scripts'))
 include_files.append((os.path.join(executable_path, 'python.exe'), 'python.exe'))


### PR DESCRIPTION
There are small typos in:
- README.md
- docs/source/development/windows_build.rst
- docs/source/king_phisher/server/graphql/middleware.rst
- king_phisher/client/export.py
- king_phisher/client/gui_utilities.py
- king_phisher/client/mailer.py
- king_phisher/client/widget/extras.py
- king_phisher/server/pylibc.py
- king_phisher/sms.py
- king_phisher/utilities.py
- tools/development/cx_freeze.py

Fixes:
- Should read `separate` rather than `seperate`.
- Should read `password` rather than `passwrd`.
- Should read `middleware` rather than `middlware`.
- Should read `worksheet` rather than `workseet`.
- Should read `styled` rather than `styeled`.
- Should read `rendering` rather than `renderering`.
- Should read `output` rather than `ouput`.
- Should read `minimum` rather than `mininum`.
- Should read `messages` rather than `messsages`.
- Should read `message` rather than `messsage`.
- Should read `executable` rather than `executible`.
- Should read `chosen` rather than `choosen`.

Closes #470