### PR TITLE
Sphinx new API

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -82,7 +82,7 @@ def gobject_signal_parse(env, sig, signode):
 	return match.group(1)
 
 def setup(app):
-	app.add_stylesheet('theme_overrides.css')
+	app.add_css_file('theme_overrides.css')
 	doc_field_types = list(copy.copy(sphinx.domains.python.PyObject.doc_field_types))
 	doc_field_types.append(sphinx.util.docfields.Field('flags', label='Signal flags', names=['flag', 'flags'], has_arg=False))
 	app.add_object_type(


### PR DESCRIPTION
> Yes, the API was deprecated at 1.8.0. Please use `app.add_css_file()` instead.

REF: https://github.com/sphinx-doc/sphinx/issues/7747

- - - 

Error:

```
dh build
   dh_update_autotools_config
   dh_autoreconf
   debian/rules override_dh_auto_build
make[1]: Entering directory '/<<PKGBUILDDIR>>'
dh_auto_build
PYTHONPATH=. http_proxy='127.0.0.1:9' sphinx-build -N -bhtml docs/source build/html
Running Sphinx v4.2.0
loading translations [en]... done
making output directory... done

Exception occurred:
  File "/<<PKGBUILDDIR>>/docs/source/conf.py", line 85, in setup
    app.add_stylesheet('theme_overrides.css')
AttributeError: 'Sphinx' object has no attribute 'add_stylesheet'
The full traceback has been saved in /tmp/sphinx-err-6f06nq1h.log, if you want to report the issue to the developers.
Please also report this if it was a user error, so that a better error message can be provided next time.
A bug report can be filed in the tracker at <https://github.com/sphinx-doc/sphinx/issues>. Thanks!
make[1]: *** [debian/rules:25: override_dh_auto_build] Error 2
make[1]: Leaving directory '/<<PKGBUILDDIR>>'
make: *** [debian/rules:4: build] Error 2
dpkg-buildpackage: error: debian/rules build subprocess returned exit status 2
```