### PR TITLE
adding empty alt text to tracking_dot_image_tag

### DIFF
--- a/king_phisher/client/mailer.py
+++ b/king_phisher/client/mailer.py
@@ -273,7 +273,7 @@ def render_message_template(template, config, target=None, analyze=False):
 	template_vars['webserver'] = webserver_url.netloc
 	tracking_url = urllib.parse.urlunparse((webserver_url.scheme, webserver_url.netloc, tracking_image, '', 'id=' + target.uid, ''))
 	webserver_url = urllib.parse.urlunparse((webserver_url.scheme, webserver_url.netloc, webserver_url.path, '', '', ''))
-	template_vars['tracking_dot_image_tag'] = "<img src=\"{0}\" style=\"display:none\" />".format(tracking_url)
+	template_vars['tracking_dot_image_tag'] = "<img src=\"{0}\" style=\"display:none\" alt=\"\" />".format(tracking_url)
 
 	template_vars_url = {}
 	template_vars_url['rickroll'] = 'http://www.youtube.com/watch?v=oHg5SJYRHA0'


### PR DESCRIPTION
Just a small commit to add an empty alt tag, because websites like https://www.mail-tester.com/ mark that as a thing to improve on if you don't have alt tag at least present (even if it is empty).

Alternatively, another solution would be to allow the user to pass a parameter to specify an alt text like how `inline_image` does, but that was a lot more work :upside_down_face: . Feel free to close it if you'd like to go an alternative route, I made the modification to my client and figured I suggest it in case anyone else thought it was useful.