### PR TITLE
distutils has been deprecated

### DIFF
--- a/king_phisher/plugins.py
+++ b/king_phisher/plugins.py
@@ -32,7 +32,7 @@
 
 import collections
 import copy
-import distutils.version
+import pacakging.version
 import functools
 import importlib
 import inspect
@@ -56,7 +56,7 @@ from king_phisher import version
 
 import pluginbase
 
-StrictVersion = distutils.version.StrictVersion
+StrictVersion = packaging.version
 
 def _recursive_reload(package, package_name, completed):
 	importlib.reload(package)

--- a/king_phisher/plugins.py
+++ b/king_phisher/plugins.py
@@ -32,7 +32,7 @@
 
 import collections
 import copy
-import pacakging.version
+import packaging.version
 import functools
 import importlib
 import inspect


### PR DESCRIPTION
when I start kingphisher server, it throw error that distutils has been deprecated
https://github.com/pytorch/pytorch/issues/69894

so I change distutils.version to packaging.version
https://github.com/pypa/packaging/issues/520